### PR TITLE
fix various compiler errors on linux gcc 11.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ endif()
 add_library(${PROJECT_NAME}
 	${TUIC_SOURCES}
 )
+
 target_include_directories(${PROJECT_NAME}
 	PUBLIC
 		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -14,6 +14,7 @@ if (UNIX)
 target_link_libraries(Example-00-Implementation
     PUBLIC
         m # for pow()
+        GL
 )
 endif()
 set_property(TARGET Example-00-Implementation PROPERTY VS_DEBUGGER_WORKING_DIRECTORY $<TARGET_FILE_DIR:Example-00-Implementation>)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,7 +1,7 @@
-file(GLOB implemntation_lib_files
+file(GLOB implementation_lib_files
 	Example-00-Implementation/*
 )
-add_library(Example-00-Implementation ${implemntation_lib_files})
+add_library(Example-00-Implementation ${implementation_lib_files})
 find_package(glfw3 CONFIG REQUIRED)
 find_package(GLEW REQUIRED)
 target_link_libraries(Example-00-Implementation
@@ -10,6 +10,12 @@ target_link_libraries(Example-00-Implementation
 		glfw
 		GLEW::GLEW
 )
+if (UNIX)
+target_link_libraries(Example-00-Implementation
+    PUBLIC
+        m # for pow()
+)
+endif()
 set_property(TARGET Example-00-Implementation PROPERTY VS_DEBUGGER_WORKING_DIRECTORY $<TARGET_FILE_DIR:Example-00-Implementation>)
 # cmake function for adding an example project
 function(add_example Name)

--- a/examples/Example-00-Implementation/impl.c
+++ b/examples/Example-00-Implementation/impl.c
@@ -10,7 +10,7 @@
 	be used if you run your project in debug configuration. If you don't even want to run these macros in debug configuration, you can define the macro GLD_ACTIVE as 0 before including the backend.
 */
 
-#include <gl/glew.h> //You need to include opengl bindings before implementing the opengl33 backend. You can use any Opengl loading library that you prefeer.
+#include <GL/glew.h> //You need to include opengl bindings before implementing the opengl33 backend. You can use any Opengl loading library that you prefeer.
 #define TUIC_OPENGL33_LOAD_GLEW //specify that glew is the library being used.
 //#define TUIC_OPENGL33_LOAD_GLAD //specify this instead of previous macro to use GLAD instead of GLEW.
 //#define TUIC_OPENGL33_LOAD_NONE //specify this to use no loading library. This will cause @ref tuiOpengl33InstanceCreateNewContext to return NULL.

--- a/examples/Example-01-Basic-Panel/main.c
+++ b/examples/Example-01-Basic-Panel/main.c
@@ -1,12 +1,14 @@
 /* This example showcases how to use a panel that uses JTUI_DETAIL_G8_C4 detail mode. This detail mode has 8 bits per glyph and 4 bits per color. This allows for up to 256 unique glyphs and for a palette of 16 colors. */
 
-#include <gl/glew.h>
+#include <GL/glew.h>
 #include <GLFW/glfw3.h>
 
 #include <TUIC/tuic.h>
 #include <TUIC/backends/opengl33.h>
 
 #include <stdio.h>
+#include <time.h>
+#include <stdlib.h>
 
 
 const size_t kTilesWide = 100;

--- a/examples/Example-02-Channel-Replace-Blend-Modes/main.c
+++ b/examples/Example-02-Channel-Replace-Blend-Modes/main.c
@@ -1,4 +1,4 @@
-#include <gl/glew.h>
+#include <GL/glew.h>
 #include <GLFW/glfw3.h>
 
 #include <TUIC/tuic.h>

--- a/examples/Example-03-Panel-Transformed-Rendering/main.c
+++ b/examples/Example-03-Panel-Transformed-Rendering/main.c
@@ -1,4 +1,4 @@
-#include <gl/glew.h>
+#include <GL/glew.h>
 #include <GLFW/glfw3.h>
 
 #include <TUIC/tuic.h>

--- a/examples/Example-04-Dynamic-Resizing/main.c
+++ b/examples/Example-04-Dynamic-Resizing/main.c
@@ -1,4 +1,4 @@
-#include <gl/glew.h>
+#include <GL/glew.h>
 #include <GLFW/glfw3.h>
 
 #include <TUIC/tuic.h>
@@ -77,7 +77,7 @@ void WindowResizeCallback(GLFWwindow* window, int width, int height)
             }
         }
         tuiPanelClearColor(usr_ptr->panel, 0, 0, 0, 0);
-        tuiPanelDrawBatch(usr_ptr->panel, usr_ptr->atlas, usr_ptr->palette, usr_ptr->batch, kSheetBlendMode);
+        tuiPanelDrawBatch(usr_ptr->panel, usr_ptr->atlas, usr_ptr->palette, usr_ptr->batch);
     }
 }
 

--- a/examples/Example-05-Basic-Text-Rendering/main.c
+++ b/examples/Example-05-Basic-Text-Rendering/main.c
@@ -1,4 +1,4 @@
-#include <gl/glew.h>
+#include <GL/glew.h>
 #include <GLFW/glfw3.h>
 
 #include <TUIC/tuic.h>

--- a/examples/Example-06-Simple-Topdown-Character/main.c
+++ b/examples/Example-06-Simple-Topdown-Character/main.c
@@ -1,4 +1,4 @@
-#include <gl/glew.h>
+#include <GL/glew.h>
 #include <GLFW/glfw3.h>
 
 #include <TUIC/tuic.h>
@@ -7,6 +7,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <time.h>
 
 const size_t kTilesWide = 100;
 const size_t kTilesTall = 80;
@@ -188,7 +189,7 @@ int main()
         tuiBatchSetTile_G8_C4_SPARSE(batch2, info.player_x, info.player_y, 2, player_color);
 
         tuiPanelClearColor(panel2, 0, 0, 0, 0);
-        tuiPanelDrawBatch(panel2, atlas, palette, batch2, kSheetBlendMode);
+        tuiPanelDrawBatch(panel2, atlas, palette, batch2);
         tuiPanelRender(panel1);
         tuiPanelRender(panel2);
 

--- a/examples/Example-07-Mouse-Input/main.c
+++ b/examples/Example-07-Mouse-Input/main.c
@@ -1,4 +1,4 @@
-#include <gl/glew.h>
+#include <GL/glew.h>
 #include <GLFW/glfw3.h>
 
 #include <TUIC/tuic.h>

--- a/examples/Example-08-Matrix-Rain/main.c
+++ b/examples/Example-08-Matrix-Rain/main.c
@@ -1,6 +1,6 @@
 /*  */
 
-#include <gl/glew.h>
+#include <GL/glew.h>
 #include <GLFW/glfw3.h>
 
 #include <TUIC/tuic.h>

--- a/include/TUIC/backends/opengl33.h
+++ b/include/TUIC/backends/opengl33.h
@@ -20,7 +20,7 @@
 /*! \file opengl33.h
  * This file includes all function prototypes for the opengl33 backend. To use this backend, it needs to be implemented in a c or cpp file somewhere  in your project using opengl33_implementation.h like so:
  * 
- *     #include <gl/glew.h> //You need to include opengl bindings before implementing the opengl33 backend. You can use any Opengl loading library that you prefeer.
+ *     #include <GL/glew.h> //You need to include opengl bindings before implementing the opengl33 backend. You can use any Opengl loading library that you prefeer.
  *     #define TUIC_OPENGL33_LOAD_GLEW //specify that glew is the library being used.
  *     //#define TUIC_OPENGL33_LOAD_GLAD //specify this instead of previous macro to use GLAD instead of GLEW.
  *     //#define TUIC_OPENGL33_LOAD_NONE //specify this to use no loading library. This will cause tuiOpengl33InstanceCreateNewContext to return NULL.
@@ -33,7 +33,7 @@
 #ifdef __cplusplus //extern C guard
 extern "C" {
 #endif
-#include "tuic/types.h"
+#include "TUIC/types.h"
 /*!
  * @brief Create a new @ref TuiInstance using the Opengl33 backend.
  * 

--- a/test/manual/opengl33_test.cpp
+++ b/test/manual/opengl33_test.cpp
@@ -1,4 +1,4 @@
-#include <gl/glew.h>
+#include <GL/glew.h>
 #include <GLFW/glfw3.h>
 
 #include <TUIC/tuic.h>

--- a/test/manual/test_impl.cpp
+++ b/test/manual/test_impl.cpp
@@ -1,4 +1,4 @@
-#include <gl/glew.h>
+#include <GL/glew.h>
 #define TUIC_OPENGL33_LOAD_GLEW
 #define TUIC_OPENGL33_IMPLEMENTATION
 #include <TUIC/backends/opengl33_implementation.h>


### PR DESCRIPTION
Most issues were due to case-sensitive naming on Unix-y platforms like Linux.

I also fixed a typo while I was there. It does not currently link, it throws pages of complaints about undefined references to `TransformMatrix`, `DrawBatchData`, etc.